### PR TITLE
vweb, all route functions/methods must be public (in latest V)

### DIFF
--- a/hello-web.v
+++ b/hello-web.v
@@ -33,7 +33,7 @@ pub fn (mut app App) init() {
 
 // serve some content on the root (index) route '/'
 // note that this implementation doesn't requires a template page ...
-fn (mut app App) index() vweb.Result {
+pub fn (mut app App) index() vweb.Result {
 	return app.vweb.json('{"Hello":"World"}')
 }
 


### PR DESCRIPTION
Hi, 
since yesterday (V build from sources) all route functions/methods must be public.
This is the small fix.

Bye
